### PR TITLE
Add mugshot support for Crawford County jail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This bot is a docker container for scraping jail websites and saving inmate data
 
 ### Current Jails
 ##### Feel free to request additional jails (or submit a pull request to add yourself). I am trying to get more jails added as I have time. If the jail uses zuercher portal then it just needs to be added to the jails.json file (or raise issue and I can do it pretty quickly). Other jails need to figure out how to scrape the website first
-| State    | Jail              | Jail ID          | Added In Version |
-|----------|-------------------|------------------|------------------|
-| Arkansas | Benton County     | benton-co-ar     | 1.0.0            |
-| Arkansas | Pulaski County    | pulaski-co-ar    | 1.0.0            |
-| Arkansas | Washington County | washington-co-ar | 2.0.0            |
-| Arkansas | Crawford County   | crawford-co-ar   | 2.1.0            |
+| State    | Jail              | Jail ID          | Added In Version | Mugshot            |
+|----------|-------------------|------------------|------------------|--------------------|
+| Arkansas | Benton County     | benton-co-ar     | 1.0.0            | :white_check_mark: |
+| Arkansas | Pulaski County    | pulaski-co-ar    | 1.0.0            | :white_check_mark: |
+| Arkansas | Washington County | washington-co-ar | 2.0.0            | :x:                |
+| Arkansas | Crawford County   | crawford-co-ar   | 2.1.0            | :white_check_mark: |
 
 ### Example Docker Compose File
 ```

--- a/scrapes/crawford_so_ar.py
+++ b/scrapes/crawford_so_ar.py
@@ -61,6 +61,8 @@ def scrape_inmate_data(details_path: str) -> dict:
     soup = bs4.BeautifulSoup(req.text, "html.parser")
     images = soup.find_all("img")
     mugshot_url = images[1]["src"]
+    if mugshot_url.startswith("/"):
+        mugshot_url = f"{URL}{mugshot_url}"
     mugshot = image_url_to_base64(mugshot_url)
     inmate_table = soup.find_all("table")[0]
     inmate_rows = inmate_table.find_all("tr")


### PR DESCRIPTION
## Summary by Sourcery

Add mugshot image retrieval and Base64 encoding for Crawford County jail scraper

New Features:
- Add functionality to fetch and encode mugshot images for inmates

Enhancements:
- Implement image_url_to_base64 function to convert image URLs to Base64
- Update scraping logic to include mugshot in inmate details

Documentation:
- Update README to indicate mugshot support for Crawford County jail