### PR TITLE
Track last seen incarcerated date

### DIFF
--- a/models/Jail.py
+++ b/models/Jail.py
@@ -1,7 +1,7 @@
 """Jail Model"""
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from loguru import logger
 from sqlalchemy.orm import relationship
 from sqlalchemy import (
@@ -10,6 +10,7 @@ from sqlalchemy import (
     String,
     Boolean,
     Date,
+    TIMESTAMP
 )
 from database_connect import Base
 from models.Inmate import Inmate
@@ -44,6 +45,7 @@ class Jail(Base):  # type: ignore
     created_date = Column(Date, nullable=False, default=date.today())
     updated_date = Column(Date, nullable=False, default=date.today())
     last_scrape_date = Column(Date, nullable=True)
+    last_successful_scrape = Column(TIMESTAMP, nullable=True, default=None)
 
     inmates = relationship("Inmate", back_populates="jail")
 
@@ -70,3 +72,4 @@ class Jail(Base):  # type: ignore
         """Update the last scrape date"""
         logger.info(f"Updating last scrape date for {self.jail_name}")
         self.last_scrape_date = date.today()
+        self.last_successful_scrape = datetime.now()  # type: ignore

--- a/models/Monitor.py
+++ b/models/Monitor.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     Date,
+    TIMESTAMP
 )
 from database_connect import Base
 from models.Inmate import Inmate
@@ -51,6 +52,7 @@ class Monitor(Base):
     enable_notifications = Column(Integer, nullable=False, default=1)
     notify_method = Column(String(255), nullable=True, default="pushover")
     notify_address = Column(String(255), nullable=False, default="")
+    last_seen_incarcerated = Column(TIMESTAMP, nullable=True, default=None)
 
     def to_dict(self) -> dict:
         """Converts the object to a dictionary"""
@@ -66,6 +68,7 @@ class Monitor(Base):
             "enable_notifications": self.enable_notifications,
             "notify_method": self.notify_method,
             "notify_address": self.notify_address,
+            "last_seen_incarcerated": self.last_seen_incarcerated,
         }
 
     def send_message(self, inmate: Inmate, released: bool = False):

--- a/scrapes/process.py
+++ b/scrapes/process.py
@@ -7,6 +7,7 @@ from models.Jail import Jail
 from models.Inmate import Inmate
 from models.Monitor import Monitor
 from helpers.insert_ignore import insert_ignore
+from datetime import datetime
 
 
 def process_scrape_data(session: Session, inmates: list[Inmate], jail: Jail):
@@ -47,6 +48,7 @@ def process_scrape_data(session: Session, inmates: list[Inmate], jail: Jail):
                     if monitor.name == inmate.name:
                         logger.trace(f"Found exact match for {monitor.name}")
                         monitor.arrest_date = inmate.arrest_date
+                        monitor.last_seen_incarcerated = datetime.now() # type: ignore
                     else:
                         logger.trace(f"Found partial match for {monitor.name}.")
                         logger.success(f"Creating new monitor for {inmate.name}")
@@ -59,6 +61,7 @@ def process_scrape_data(session: Session, inmates: list[Inmate], jail: Jail):
                             enable_notifications=monitor.enable_notifications,
                             notify_method=monitor.notify_method,
                             notify_address=monitor.notify_address,
+                            last_seen_incarcerated=datetime.now(),
                         )
                         session.add(new_monitor)
                     monitor.send_message(inmate)


### PR DESCRIPTION
## Summary by Sourcery

Add tracking of the last time a monitored inmate was seen as incarcerated

New Features:
- Add a new column 'last_seen_incarcerated' to the Monitor model to track when an inmate was last confirmed to be in jail

Enhancements:
- Update process_scrape_data function to set the last_seen_incarcerated timestamp when an inmate is matched