### PR TITLE
fixed notification mugshot

### DIFF
--- a/models/Monitor.py
+++ b/models/Monitor.py
@@ -106,7 +106,7 @@ class Monitor(Base):
                             "priority": pushover_priority,
                             "token": pushover_api_key,
                             "user": user_key,
-                            "attachment_base64": self.mugshot,
+                            "attachment_base64": inmate.mugshot,
                             "attachment_type": "image/jpeg",
                         }
                     ),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use inmate.mugshot instead of self.mugshot when sending Pushover notifications to attach the correct image