### PR TITLE
Clear release date on arrest date update

### DIFF
--- a/scrapes/process_optimized.py
+++ b/scrapes/process_optimized.py
@@ -63,6 +63,7 @@ def process_scrape_data_optimized(session: Session, inmates: List[Inmate], jail:
             if monitor.arrest_date != inmate.arrest_date:
                 logger.trace(f"New arrest date for {monitor.name}")
                 monitor.arrest_date = inmate.arrest_date
+                monitor.release_date = None # type: ignore
                 monitor.send_message(inmate)
                 inmate_processed = True
             elif (


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set monitor.release_date to None whenever monitor.arrest_date is updated