### PR TITLE
Implement batch upserts and adjust database timeouts

### DIFF
--- a/DATABASE_TIMEOUT_BATCH_FIX.md
+++ b/DATABASE_TIMEOUT_BATCH_FIX.md
@@ -1,0 +1,105 @@
+# Database Session Isolation and MySQL Timeout Fix
+
+## Problem Analysis
+
+The Pulaski County Zuercher scraper was experiencing two distinct issues:
+
+1. **Read Lock Errors** (FIXED) - Session sharing between jails causing lock inheritance
+2. **MySQL Timeout Errors** (NEW) - Large dataset causing query timeouts during bulk operations
+
+## Issue #1: Read Lock Errors (RESOLVED ✅)
+
+### Root Cause
+Session sharing between jails in the main processing loop caused lock inheritance from previous jail operations.
+
+### Solution Implemented
+- **Individual Session Isolation**: Each jail gets its own fresh database session
+- **Enhanced Connection Settings**: Improved pooling and isolation levels
+- **Better Error Handling**: Explicit rollback and session cleanup
+
+### Results
+✅ **Benton County**: Completed successfully  
+✅ **No Read Lock Errors**: Session isolation eliminated lock inheritance  
+✅ **Clean Session Lifecycle**: Each jail starts with a fresh database state
+
+## Issue #2: MySQL Timeout Errors (CURRENT)
+
+### Root Cause
+Pulaski County has 1,226 inmates (vs Benton's 680), causing the single large upsert operation to exceed MySQL's 30-second timeout.
+
+### Error Details
+```
+(2013, 'Lost connection to MySQL server during query (timed out)')
+```
+
+### Solution Implemented
+1. **Optimized Batch Processing**: Using `DatabaseOptimizer.batch_upsert_inmates()` with 50-record batches
+2. **Increased Timeouts**: MySQL connection timeouts increased to 60s/120s/120s  
+3. **Fallback Strategy**: Individual upserts if batch operation fails
+4. **Transaction Management**: Smaller batch commits to prevent long-running transactions
+
+### Key Changes
+
+**Enhanced Database Connection (`database_connect.py`)**:
+```python
+'connect_args': {
+    'connect_timeout': 60,     # Increased from 10s
+    'read_timeout': 120,       # Increased from 30s  
+    'write_timeout': 120,      # Increased from 30s
+}
+```
+
+**Optimized Batch Processing (`process_optimized.py`)**:
+```python
+# Use optimized batch upsert instead of individual operations
+DatabaseOptimizer.batch_upsert_inmates(
+    session=session, 
+    inmates_data=inmates_data, 
+    batch_size=50  # Smaller batches for timeout prevention
+)
+```
+
+### Expected Results
+- ✅ **Faster Processing**: Batch operations vs individual upserts
+- ✅ **Timeout Prevention**: Smaller batch sizes prevent MySQL timeouts  
+- ✅ **Better Reliability**: Fallback strategy ensures operation completes
+- ✅ **Scalability**: Can handle jails with 1,000+ inmates
+
+## Testing
+
+Run the Docker Compose setup to test both fixes:
+
+```bash
+cd /path/to/incarceration_bot
+docker compose up
+```
+
+**Expected Log Pattern**:
+```
+🔍 Starting scrape for Benton County AR Jail (Zuercher Portal)
+✅ Successfully completed Benton County AR Jail
+🔒 Closed database session for Benton County AR Jail
+
+🔍 Starting scrape for Pulaski County AR Jail (Zuercher Portal)  
+📊 Found 1226 records for Pulaski County AR Jail
+💾 Processing 1226 inmates with optimized batch upsert
+✅ Successfully completed optimized batch upsert
+✅ Successfully completed Pulaski County AR Jail
+🔒 Closed database session for Pulaski County AR Jail
+```
+
+## Files Modified
+
+1. **`/backend/main.py`** - Session isolation for each jail
+2. **`/backend/database_connect.py`** - Enhanced connection settings and timeouts
+3. **`/backend/scrapes/zuercher.py`** - Better error handling and logging
+4. **`/backend/scrapes/process_optimized.py`** - Batch processing with DatabaseOptimizer
+5. **`/backend/DATABASE_SESSION_ISOLATION_FIX.md`** - Documentation
+
+## Summary
+
+- **Phase 1 ✅**: Session isolation fixed read lock errors
+- **Phase 2 🔄**: Batch processing + timeouts should fix MySQL timeout errors
+- **Both jails should now process successfully** without interference
+
+The system now handles both small jails (like Benton with 680 inmates) and large jails (like Pulaski with 1,226 inmates) efficiently and reliably.

--- a/backend/database_connect.py
+++ b/backend/database_connect.py
@@ -49,11 +49,11 @@ def new_session() -> Session:
             'isolation_level': 'READ_COMMITTED',  # Reduce lock contention
             'echo': False,  # Set to True for debugging SQL queries
             'connect_args': {
-                'connect_timeout': 10,  # Connection timeout
-                'read_timeout': 30,     # Read timeout
-                'write_timeout': 30,    # Write timeout
-                'autocommit': False,    # Explicit transaction control
-                'charset': 'utf8mb4'    # Full UTF-8 support
+                'connect_timeout': 60,     # Increased connection timeout
+                'read_timeout': 120,       # Increased read timeout for large operations  
+                'write_timeout': 120,      # Increased write timeout for large operations
+                'autocommit': False,       # Explicit transaction control
+                'charset': 'utf8mb4'       # Full UTF-8 support
             }
         }
     else:

--- a/backend/database_connect.py
+++ b/backend/database_connect.py
@@ -50,10 +50,11 @@ def new_session() -> Session:
             'echo': False,  # Set to True for debugging SQL queries
             'connect_args': {
                 'connect_timeout': 60,     # Increased connection timeout
-                'read_timeout': 120,       # Increased read timeout for large operations  
-                'write_timeout': 120,      # Increased write timeout for large operations
+                'read_timeout': 300,       # 5 minutes for large batch operations  
+                'write_timeout': 300,      # 5 minutes for large batch operations
                 'autocommit': False,       # Explicit transaction control
-                'charset': 'utf8mb4'       # Full UTF-8 support
+                'charset': 'utf8mb4',      # Full UTF-8 support
+                'sql_mode': 'TRADITIONAL,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO'
             }
         }
     else:

--- a/backend/maintenance_release_dates.py
+++ b/backend/maintenance_release_dates.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Release Date Maintenance Script
+
+This script processes release date updates for large jails that were deferred
+during the main scraping process to avoid lock contention and timeouts.
+
+Can be run as a separate background job or cron task.
+"""
+
+import os
+import sys
+import time
+from datetime import date, datetime, timedelta
+from loguru import logger
+
+# Add the backend directory to the path
+sys.path.append(os.path.join(os.path.dirname(__file__)))
+
+from database_connect import new_session
+from models.Inmate import Inmate
+from models.Jail import Jail
+from helpers.database_optimizer import DatabaseOptimizer
+
+
+def process_deferred_release_dates(jail_id: str = None, batch_size: int = 3, delay_between_batches: float = 2.0):
+    """
+    Process release date updates that were deferred during main scraping.
+    
+    Args:
+        jail_id: Specific jail to process, or None for all jails
+        batch_size: Very small batch size to avoid lock contention
+        delay_between_batches: Seconds to wait between batches
+    """
+    session = new_session()
+    
+    try:
+        # Configure session for background processing
+        session.execute("SET SESSION transaction_isolation = 'READ-UNCOMMITTED'")
+        session.execute("SET SESSION innodb_lock_wait_timeout = 10")
+        
+        # Get jails to process
+        if jail_id:
+            jails = session.query(Jail).filter(Jail.jail_id == jail_id).all()
+        else:
+            jails = session.query(Jail).filter(Jail.enabled == True).all()
+        
+        logger.info(f"Processing deferred release dates for {len(jails)} jails")
+        
+        for jail in jails:
+            logger.info(f"Processing release dates for {jail.jail_name}")
+            
+            # Get inmates that need release date updates
+            today = date.today()
+            yesterday = today - timedelta(days=1)
+            yesterday_start = datetime.combine(yesterday, datetime.min.time())
+            
+            inmates_to_update = (
+                session.query(Inmate)
+                .filter(
+                    Inmate.jail_id == jail.jail_id,
+                    Inmate.release_date.in_(["", None]),
+                    Inmate.last_seen < yesterday_start  # Not seen since yesterday
+                )
+                .all()
+            )
+            
+            if not inmates_to_update:
+                logger.debug(f"No deferred release dates to process for {jail.jail_name}")
+                continue
+            
+            logger.info(f"Found {len(inmates_to_update)} inmates needing release date updates in {jail.jail_name}")
+            
+            # Get current inmates for this jail (from today's scrape)
+            current_inmates = (
+                session.query(Inmate)
+                .filter(
+                    Inmate.jail_id == jail.jail_id,
+                    Inmate.last_seen >= datetime.combine(today, datetime.min.time())
+                )
+                .all()
+            )
+            
+            # Create lookup set of current inmates
+            current_identifiers = {
+                (str(inmate.name).strip().lower(), inmate.arrest_date) 
+                for inmate in current_inmates
+            }
+            
+            # Collect release date updates
+            release_updates = []
+            for inmate in inmates_to_update:
+                inmate_identifier = (str(inmate.name).strip().lower(), inmate.arrest_date)
+                
+                if inmate_identifier not in current_identifiers:
+                    # This inmate is no longer in current roster - set release date
+                    if inmate.last_seen:
+                        release_date_str = inmate.last_seen.date().isoformat()
+                    else:
+                        release_date_str = yesterday.isoformat()
+                    
+                    release_updates.append((inmate.id, release_date_str))
+            
+            # Process updates with background-friendly method
+            if release_updates:
+                updated_count = DatabaseOptimizer.batch_update_release_dates_background(
+                    session, release_updates, batch_size=batch_size
+                )
+                logger.info(f"Updated {updated_count} release dates for {jail.jail_name}")
+                
+                # Wait between jails to be extra gentle
+                if delay_between_batches > 0:
+                    time.sleep(delay_between_batches)
+            else:
+                logger.debug(f"No release date updates needed for {jail.jail_name}")
+        
+        logger.info("Completed deferred release date processing")
+        
+    except Exception as e:
+        logger.error(f"Error in deferred release date processing: {e}")
+        session.rollback()
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Process deferred release date updates")
+    parser.add_argument("--jail-id", help="Specific jail ID to process")
+    parser.add_argument("--batch-size", type=int, default=3, help="Batch size for updates")
+    parser.add_argument("--delay", type=float, default=2.0, help="Delay between batches (seconds)")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+    
+    args = parser.parse_args()
+    
+    if args.verbose:
+        logger.add(sys.stdout, level="DEBUG")
+    else:
+        logger.add(sys.stdout, level="INFO")
+    
+    process_deferred_release_dates(
+        jail_id=args.jail_id,
+        batch_size=args.batch_size,
+        delay_between_batches=args.delay
+    )

--- a/backend/scrapes/process_optimized.py
+++ b/backend/scrapes/process_optimized.py
@@ -369,7 +369,9 @@ def update_release_dates_for_missing_inmates(
     if release_updates:
         from helpers.database_optimizer import DatabaseOptimizer
         try:
-            updated_count = DatabaseOptimizer.batch_update_release_dates(session, release_updates, batch_size=25)
+            # Use very small batch size to prevent deadlocks on large updates
+            batch_size = 10 if len(release_updates) > 50 else 25
+            updated_count = DatabaseOptimizer.batch_update_release_dates(session, release_updates, batch_size=batch_size)
             logger.info(f"Updated release dates for {updated_count} inmates in {jail.jail_name}")
         except Exception as e:
             logger.error(f"Failed to batch update release dates: {e}")


### PR DESCRIPTION
## Summary by Sourcery

Optimize inmate processing by batching upserts to prevent MySQL timeouts, update database timeout settings for large operations, introduce a fallback strategy with improved error handling, and add documentation explaining the changes

New Features:
- Introduce optimized batch upsert for inmate records via DatabaseOptimizer.batch_upsert_inmates with a fallback to individual upserts on failure

Enhancements:
- Increase MySQL connect_timeout to 60s and read/write timeouts to 120s to support large bulk operations
- Add per-batch commits and enhanced error handling and logging in the inmate processing workflow

Documentation:
- Add DATABASE_TIMEOUT_BATCH_FIX.md documenting the root causes, batch processing solution, timeout configuration changes, and testing instructions